### PR TITLE
修正环境变量设置文档中的文件名引用错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install
 
 3. Set up environment variables:
 ```bash
-cp env.example .env
+cp .env.example .env
 # Edit .env with your OpenRouter API key and configuration
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,7 +19,7 @@ npm install
 复制环境变量模板：
 
 ```bash
-cp env.example .env
+cp .env.example .env
 ```
 
 编辑 `.env` 文件，配置必要的环境变量：

--- a/docs/git-setup.md
+++ b/docs/git-setup.md
@@ -169,7 +169,7 @@ openai-router/
 ├── 📄 jest.config.js          # Jest 测试配置
 ├── 📄 .prettierrc             # Prettier 格式化配置
 ├── 📄 .gitignore              # Git 忽略规则
-├── 📄 env.example             # 环境变量示例
+├── 📄 .env.example            # 环境变量示例
 └── 📄 README.md               # 项目说明
 ```
 

--- a/docs/project-summary.md
+++ b/docs/project-summary.md
@@ -136,7 +136,7 @@ src/
 ### 开发环境
 ```bash
 npm install
-cp env.example .env
+cp .env.example .env
 npm run dev
 ```
 


### PR DESCRIPTION
## 变更内容
- 修正了 README.md 中的环境变量设置命令，将 `cp env.example .env` 更正为 `cp .env.example .env`
- 更新了 docs/getting-started.md 中的环境变量复制命令，保持与实际文件名一致
- 修正了 docs/git-setup.md 中的项目结构图，将 `env.example` 更正为 `.env.example`
- 更新了 docs/project-summary.md 中的开发环境设置指令，使用正确的文件名

## 变更原因
- 项目中的环境变量示例文件实际命名为 `.env.example`（以点开头），但在文档中错误地引用为 `env.example`
- 此不一致导致开发者在按照文档操作时可能遇到文件未找到的错误
- 统一文档中的文件引用以匹配实际项目结构，提升开发者体验

## 测试方法
- 验证所有修改后的文档中的命令是否能正确执行
- 确认 `.env.example` 文件确实存在于项目根目录中
- 检查文档中的文件结构图是否与实际项目结构一致